### PR TITLE
막차 시간 계산 로직 변경

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("kotlin-android")
     id("com.google.dagger.hilt.android")
     id("com.google.devtools.ksp")
+    id("kotlin-kapt")
 }
 
 val properties = Properties()
@@ -88,7 +89,7 @@ dependencies {
     implementation("com.tickaroo.tikxml:annotation:0.8.13")
     implementation("com.tickaroo.tikxml:core:0.8.13")
     implementation("com.tickaroo.tikxml:retrofit-converter:0.8.13")
-    ksp("com.tickaroo.tikxml:processor:0.8.13")
+    kapt("com.tickaroo.tikxml:processor:0.8.13")
 
     // Room
     implementation("androidx.room:room-runtime:2.6.1")

--- a/data/src/main/java/com/stop/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/stop/data/di/NetworkModule.kt
@@ -15,8 +15,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
+import okhttp3.Protocol
 import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -164,6 +167,19 @@ internal object NetworkModule {
             val url = chain.request().url.toUri().toString()
 
             val (name: String, key: String) = when {
+//                url.contains("transit/routes") -> {
+//                    val response = readJson("response.json")
+//                    return chain.proceed(chain.request())
+//                        .newBuilder()
+//                        .code(200)
+//                        .protocol(Protocol.HTTP_2)
+//                        .message("success")
+//                        .body(
+//                            response.toByteArray()
+//                                .toResponseBody("application/json".toMediaTypeOrNull())
+//                        ).addHeader("content-type", "application/json")
+//                        .build()
+//                }
                 url.contains(BuildConfig.OPEN_API_SEOUL_URL) -> Pair(
                     OPEN_API_SEOUL_KEY_NAME,
                     BuildConfig.BUS_KEY
@@ -189,6 +205,10 @@ internal object NetworkModule {
                     .build()
                 proceed(newRequest)
             }
+        }
+        private fun readJson(fileName: String): String {
+            return Thread.currentThread().contextClassLoader?.getResource(fileName)
+                ?.readText() ?: ""
         }
     }
 }

--- a/data/src/main/java/com/stop/data/model/route/BusRouteListItem.kt
+++ b/data/src/main/java/com/stop/data/model/route/BusRouteListItem.kt
@@ -1,0 +1,31 @@
+package com.stop.data.model.route
+
+import com.stop.domain.model.route.seoul.bus.BusRouteInfo
+
+data class BusRouteListItem(
+    val busRouteAbrv: String,
+    val busRouteId: String,
+    val busRouteNm: String,
+    val corpNm: String,
+    val edStationNm: String,
+    val firstBusTm: String,
+    val firstLowTm: String,
+    val lastBusTm: String,
+    val lastBusYn: String,
+    val lastLowTm: String,
+    val length: String,
+    val routeType: String,
+    val stStationNm: String,
+    val term: String
+) {
+    fun toDomain(): BusRouteInfo {
+        return BusRouteInfo(
+            busRouteName = busRouteNm,
+            busRouteAbbreviation = busRouteAbrv,
+            busRouteId = busRouteId,
+            term = term.toInt(),
+            corpName = corpNm,
+            lastBusTime = lastBusTm,
+        )
+    }
+}

--- a/data/src/main/java/com/stop/data/model/route/BusRouteListMsgBody.kt
+++ b/data/src/main/java/com/stop/data/model/route/BusRouteListMsgBody.kt
@@ -1,0 +1,8 @@
+package com.stop.data.model.route
+
+import com.squareup.moshi.Json
+
+data class BusRouteListMsgBody(
+    @Json(name="itemList")
+    val busRouteListItemList: List<BusRouteListItem>
+)

--- a/data/src/main/java/com/stop/data/model/route/BusRouteListResponse.kt
+++ b/data/src/main/java/com/stop/data/model/route/BusRouteListResponse.kt
@@ -1,0 +1,10 @@
+package com.stop.data.model.route
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class BusRouteListResponse(
+    @Json(name = "msgBody")
+    val msgBody: BusRouteListMsgBody
+)

--- a/data/src/main/java/com/stop/data/model/route/BusStationsItem.kt
+++ b/data/src/main/java/com/stop/data/model/route/BusStationsItem.kt
@@ -1,0 +1,37 @@
+package com.stop.data.model.route
+
+import com.stop.domain.model.route.seoul.bus.BusStationInfo
+
+data class BusStationsItem(
+    val arsId: String,
+    val beginTm: String,
+    val busRouteAbrv: String,
+    val busRouteId: String,
+    val busRouteNm: String,
+    val direction: String,
+    val fullSectDist: String,
+    val gpsX: String,
+    val gpsY: String,
+    val lastTm: String,
+    val posX: String,
+    val posY: String,
+    val routeType: String,
+    val sectSpd: String,
+    val section: String,
+    val seq: String,
+    val station: String,
+    val stationNm: String,
+    val stationNo: String,
+    val transYn: String,
+    val trnstnid: String
+) {
+    fun toDomain(): BusStationInfo {
+        return BusStationInfo(
+            startTime = beginTm,
+            lastTime = lastTm,
+            stationName = stationNm,
+            stationId = station,
+            stationNumber = stationNo
+        )
+    }
+}

--- a/data/src/main/java/com/stop/data/model/route/BusStationsItem.kt
+++ b/data/src/main/java/com/stop/data/model/route/BusStationsItem.kt
@@ -9,7 +9,7 @@ data class BusStationsItem(
     val busRouteId: String,
     val busRouteNm: String,
     val direction: String,
-    val fullSectDist: String,
+    val fullSectDist: String?,
     val gpsX: String,
     val gpsY: String,
     val lastTm: String,

--- a/data/src/main/java/com/stop/data/model/route/BusStationsMsgBody.kt
+++ b/data/src/main/java/com/stop/data/model/route/BusStationsMsgBody.kt
@@ -1,0 +1,8 @@
+package com.stop.data.model.route
+
+import com.squareup.moshi.Json
+
+data class BusStationsMsgBody(
+    @Json(name="itemList")
+    val busStationsItemList: List<BusStationsItem>
+)

--- a/data/src/main/java/com/stop/data/model/route/BusStationsResponse.kt
+++ b/data/src/main/java/com/stop/data/model/route/BusStationsResponse.kt
@@ -1,0 +1,10 @@
+package com.stop.data.model.route
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class BusStationsResponse(
+    @Json(name = "msgBody")
+    val msgBody: BusStationsMsgBody
+)

--- a/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusLastTimeMsgBody.kt
+++ b/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusLastTimeMsgBody.kt
@@ -1,0 +1,10 @@
+package com.stop.data.remote.model.route.gyeonggi
+
+import com.tickaroo.tikxml.annotation.Element
+import com.tickaroo.tikxml.annotation.Xml
+
+@Xml(name = "msgBody")
+internal data class GyeonggiBusLastTimeMsgBody(
+    @Element(name = "busRouteInfoItem")
+    val lastTimes: List<GyeonggiBusLastTime>
+)

--- a/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusLastTimeResponse.kt
+++ b/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusLastTimeResponse.kt
@@ -1,12 +1,10 @@
 package com.stop.data.remote.model.route.gyeonggi
 
 import com.tickaroo.tikxml.annotation.Element
-import com.tickaroo.tikxml.annotation.Path
 import com.tickaroo.tikxml.annotation.Xml
 
 @Xml(name = "response")
 internal data class GyeonggiBusLastTimeResponse(
-    @Path("msgBody")
-    @Element(name = "busRouteInfoItem")
-    val lastTimes: List<GyeonggiBusLastTime>
+    @Element(name = "msgBody")
+    val msgBody: GyeonggiBusLastTimeMsgBody
 )

--- a/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusRouteIdMsgBody.kt
+++ b/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusRouteIdMsgBody.kt
@@ -4,7 +4,7 @@ import com.tickaroo.tikxml.annotation.Element
 import com.tickaroo.tikxml.annotation.Xml
 
 @Xml(name = "response")
-internal data class GyeonggiBusStationIdResponse(
-    @Element(name = "msgBody")
-    val msgBody: GyeonggiBusStationMsgBody
+internal data class GyeonggiBusRouteIdMsgBody(
+    @Element(name = "busRouteList")
+    val routes: List<GyeonggiBusRoute>
 )

--- a/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusRouteIdResponse.kt
+++ b/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusRouteIdResponse.kt
@@ -1,12 +1,10 @@
 package com.stop.data.remote.model.route.gyeonggi
 
 import com.tickaroo.tikxml.annotation.Element
-import com.tickaroo.tikxml.annotation.Path
 import com.tickaroo.tikxml.annotation.Xml
 
 @Xml(name = "response")
 internal data class GyeonggiBusRouteIdResponse(
-    @Path("msgBody")
-    @Element(name = "busRouteList")
-    val routes: List<GyeonggiBusRoute>
+    @Element(name = "msgBody")
+    val msgBody: GyeonggiBusRouteIdMsgBody
 )

--- a/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusRouteStationsMsgBody.kt
+++ b/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusRouteStationsMsgBody.kt
@@ -1,0 +1,10 @@
+package com.stop.data.remote.model.route.gyeonggi
+
+import com.tickaroo.tikxml.annotation.Element
+import com.tickaroo.tikxml.annotation.Xml
+
+@Xml(name = "msgBody")
+internal data class GyeonggiBusRouteStationsMsgBody(
+    @Element(name = "busRouteStationList")
+    val stations: List<GyeonggiBusStation>
+)

--- a/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusRouteStationsResponse.kt
+++ b/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusRouteStationsResponse.kt
@@ -1,12 +1,10 @@
 package com.stop.data.remote.model.route.gyeonggi
 
 import com.tickaroo.tikxml.annotation.Element
-import com.tickaroo.tikxml.annotation.Path
 import com.tickaroo.tikxml.annotation.Xml
 
 @Xml(name = "response")
 internal data class GyeonggiBusRouteStationsResponse(
-    @Path("msgBody")
-    @Element(name = "busRouteStationList")
-    val stations: List<GyeonggiBusStation>
+    @Element(name = "msgBody")
+    val msgBody: GyeonggiBusRouteStationsMsgBody
 )

--- a/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusStationMsgBody.kt
+++ b/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusStationMsgBody.kt
@@ -1,0 +1,10 @@
+package com.stop.data.remote.model.route.gyeonggi
+
+import com.tickaroo.tikxml.annotation.Element
+import com.tickaroo.tikxml.annotation.Xml
+
+@Xml(name = "msgBody")
+internal data class GyeonggiBusStationMsgBody(
+    @Element(name = "busStationList")
+    val busStations: List<GyeonggiBusStation>
+)

--- a/data/src/main/java/com/stop/data/remote/network/OpenApiSeoulService.kt
+++ b/data/src/main/java/com/stop/data/remote/network/OpenApiSeoulService.kt
@@ -20,12 +20,12 @@ internal interface OpenApiSeoulService {
         @Path("END_INDEX") endIndex: Int = 5,
     ): NetworkResult<SubwayStationResponse>
 
-    @GET("{KEY}/{TYPE}/{SERVICE}/{START_INDEX}/{END_INDEX}/%20/%20/{LINE_NAME}")
+    @GET("{KEY}/{TYPE}/{SERVICE}/{START_INDEX}/{END_INDEX}/%20/%20/%20/{LINE_NUM}")
     suspend fun getSubwayStations(
         @Path("KEY") key: String = BuildConfig.SUBWAY_KEY,
         @Path("TYPE") type: String = "json",
         @Path("SERVICE") serviceName: String,
-        @Path("LINE_NAME") lineName: String,
+        @Path("LINE_NUM") lineName: String,
         @Path("START_INDEX") startIndex: Int = 1,
         @Path("END_INDEX") endIndex: Int = 200,
     ): NetworkResult<SubwayStationsResponse>

--- a/data/src/main/java/com/stop/data/remote/network/WsBusApiService.kt
+++ b/data/src/main/java/com/stop/data/remote/network/WsBusApiService.kt
@@ -1,5 +1,7 @@
 package com.stop.data.remote.network
 
+import com.stop.data.model.route.BusRouteListResponse
+import com.stop.data.model.route.BusStationsResponse
 import com.stop.data.remote.model.NetworkResult
 import com.stop.data.remote.model.nowlocation.bus.BusNowLocationResponse
 import com.stop.domain.model.route.seoul.bus.BusLastTimeResponse
@@ -35,11 +37,25 @@ internal interface WsBusApiService {
         @Query("resultType") resultType: String = "json",
     ): NetworkResult<BusLastTimeResponse>
 
+    @GET(GET_BUS_ROUTE_LIST_URL)
+    suspend fun getBusRouteList(
+        @Query("strSrch") routeName: String,
+        @Query("resultType") resultType: String = JSON,
+    ): NetworkResult<BusRouteListResponse>
+
+    @GET(GET_BUS_STATIONS_URL)
+    suspend fun getBusStations(
+        @Query("busRouteId") routeId: String,
+        @Query("resultType") resultType: String = JSON,
+    ): NetworkResult<BusStationsResponse>
+
     companion object {
         private const val GET_BUS_ARS_URL = "stationinfo/getStationByName"
         private const val GET_BUS_NOW_LOCATION_URL = "buspos/getBusPosByRtid"
         private const val JSON = "json"
         private const val GET_BUS_LINE_URL = "stationinfo/getRouteByStation"
         private const val GET_BUS_LAST_TIME_URL = "stationinfo/getBustimeByStation"
+        private const val GET_BUS_ROUTE_LIST_URL = "busRouteInfo/getBusRouteList"
+        private const val GET_BUS_STATIONS_URL = "busRouteInfo/getStaionByRoute"
     }
 }

--- a/data/src/main/java/com/stop/data/remote/source/route/RouteRemoteDataSource.kt
+++ b/data/src/main/java/com/stop/data/remote/source/route/RouteRemoteDataSource.kt
@@ -1,5 +1,6 @@
 package com.stop.data.remote.source.route
 
+import com.stop.domain.model.route.seoul.subway.StationType
 import com.stop.domain.model.geoLocation.AddressType
 import com.stop.domain.model.route.gyeonggi.*
 import com.stop.domain.model.route.seoul.bus.BusRouteInfo
@@ -21,7 +22,7 @@ internal interface RouteRemoteDataSource {
     suspend fun getRoute(routeRequest: RouteRequest): List<Itinerary>
     suspend fun reverseGeocoding(coordinate: Coordinate, addressType: AddressType): ReverseGeocodingResponse
 
-    suspend fun getSubwayStationCd(stationId: String, stationName: String): String
+    suspend fun getSubwayStationCd(stationType: StationType, stationName: String): String
     suspend fun getSubwayStations(lineName: String): List<Station>
     suspend fun getSubwayStationLastTime(
         stationId: String,

--- a/data/src/main/java/com/stop/data/remote/source/route/RouteRemoteDataSource.kt
+++ b/data/src/main/java/com/stop/data/remote/source/route/RouteRemoteDataSource.kt
@@ -4,6 +4,8 @@ import com.stop.domain.model.geoLocation.AddressType
 import com.stop.domain.model.route.gyeonggi.*
 import com.stop.domain.model.route.seoul.bus.BusRouteInfo
 import com.stop.domain.model.route.seoul.bus.BusStationInfo
+import com.stop.domain.model.route.seoul.bus.SeoulBusRouteInfo
+import com.stop.domain.model.route.seoul.bus.SeoulBusStationInfo
 import com.stop.domain.model.route.seoul.bus.LastTimeInfo
 import com.stop.domain.model.route.seoul.subway.Station
 import com.stop.domain.model.route.seoul.subway.StationLastTime
@@ -27,12 +29,14 @@ internal interface RouteRemoteDataSource {
         weekType: WeekType,
     ): List<StationLastTime>
 
-    suspend fun getSeoulBusStationArsId(stationName: String): List<BusStationInfo>
-    suspend fun getSeoulBusRoute(stationId: String): List<BusRouteInfo>
+    suspend fun getSeoulBusStationArsId(stationName: String): List<SeoulBusStationInfo>
+    suspend fun getSeoulBusRoute(stationId: String): List<SeoulBusRouteInfo>
     suspend fun getSeoulBusLastTime(stationId: String, lineId: String): List<LastTimeInfo>
 
     suspend fun getGyeonggiBusStationId(stationName: String): List<GyeonggiBusStation>
     suspend fun getGyeonggiBusRoute(stationId: String): List<GyeonggiBusRoute>
     suspend fun getGyeonggiBusLastTime(lineId: String): List<GyeonggiBusLastTime>
     suspend fun getGyeonggiBusRouteStations(lineId: String): List<GyeonggiBusStation>
+    suspend fun getBusRouteList(routeName: String): List<BusRouteInfo>
+    suspend fun getBusStations(routeId: String): List<BusStationInfo>
 }

--- a/data/src/main/java/com/stop/data/remote/source/route/RouteRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/stop/data/remote/source/route/RouteRemoteDataSourceImpl.kt
@@ -177,7 +177,7 @@ internal class RouteRemoteDataSourceImpl @Inject constructor(
     override suspend fun getGyeonggiBusStationId(stationName: String): List<GyeonggiBusStation> {
         with(apisDataService.getBusStationId(stationName)) {
             return when (this) {
-                is NetworkResult.Success -> this.data.busStations.map { it.toDomain() }
+                is NetworkResult.Success -> this.data.msgBody.busStations.map { it.toDomain() }
                 is NetworkResult.Failure -> throw IllegalArgumentException(this.message)
                 is NetworkResult.NetworkError -> throw this.exception
                 is NetworkResult.Unexpected -> throw this.exception
@@ -188,7 +188,7 @@ internal class RouteRemoteDataSourceImpl @Inject constructor(
     override suspend fun getGyeonggiBusRoute(stationId: String): List<GyeonggiBusRoute> {
         with(apisDataService.getBusRouteId(stationId)) {
             return when (this) {
-                is NetworkResult.Success -> this.data.routes.map { it.toDomain() }
+                is NetworkResult.Success -> this.data.msgBody.routes.map { it.toDomain() }
                 is NetworkResult.Failure -> throw IllegalArgumentException(this.message)
                 is NetworkResult.NetworkError -> throw this.exception
                 is NetworkResult.Unexpected -> throw this.exception
@@ -199,7 +199,7 @@ internal class RouteRemoteDataSourceImpl @Inject constructor(
     override suspend fun getGyeonggiBusLastTime(lineId: String): List<GyeonggiBusLastTime> {
         with(apisDataService.getBusLastTime(lineId)) {
             return when (this) {
-                is NetworkResult.Success -> this.data.lastTimes.map { it.toDomain() }
+                is NetworkResult.Success -> this.data.msgBody.lastTimes.map { it.toDomain() }
                 is NetworkResult.Failure -> throw IllegalArgumentException(this.message)
                 is NetworkResult.NetworkError -> throw this.exception
                 is NetworkResult.Unexpected -> throw this.exception
@@ -210,7 +210,7 @@ internal class RouteRemoteDataSourceImpl @Inject constructor(
     override suspend fun getGyeonggiBusRouteStations(lineId: String): List<GyeonggiBusStation> {
         with(apisDataService.getBusRouteStations(lineId)) {
             return when (this) {
-                is NetworkResult.Success -> this.data.stations.map { it.toDomain() }
+                is NetworkResult.Success -> this.data.msgBody.stations.map { it.toDomain() }
                 is NetworkResult.Failure -> throw IllegalArgumentException(this.message)
                 is NetworkResult.NetworkError -> throw this.exception
                 is NetworkResult.Unexpected -> throw this.exception

--- a/data/src/main/java/com/stop/data/repository/RouteRepositoryImpl.kt
+++ b/data/src/main/java/com/stop/data/repository/RouteRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.stop.data.repository
 
 import com.squareup.moshi.JsonDataException
+import com.stop.domain.model.route.seoul.subway.StationType
 import com.stop.data.remote.source.route.RouteRemoteDataSource
 import com.stop.domain.model.geoLocation.AddressType
 import com.stop.domain.model.nowlocation.SubwayRouteLocationUseCaseItem
@@ -36,9 +37,9 @@ internal class RouteRepositoryImpl @Inject constructor(
         return remoteDataSource.reverseGeocoding(coordinate, addressType)
     }
 
-    override suspend fun getSubwayStationCd(stationId: String, stationName: String): String {
+    override suspend fun getSubwayStationCd(stationType: StationType, stationName: String): String {
         return try {
-            remoteDataSource.getSubwayStationCd(stationId, stationName)
+            remoteDataSource.getSubwayStationCd(stationType, stationName)
         } catch (exception: JsonDataException) {
             ""
         } catch (exception: IllegalArgumentException) {

--- a/data/src/main/java/com/stop/data/repository/RouteRepositoryImpl.kt
+++ b/data/src/main/java/com/stop/data/repository/RouteRepositoryImpl.kt
@@ -92,7 +92,7 @@ internal class RouteRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getSeoulBusStationArsId(stationName: String): List<BusStationInfo> {
+    override suspend fun getSeoulBusStationArsId(stationName: String): List<SeoulBusStationInfo> {
         return  try {
             remoteDataSource.getSeoulBusStationArsId(stationName)
         } catch (exception: JsonDataException) {
@@ -100,7 +100,7 @@ internal class RouteRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getSeoulBusRoute(stationId: String): List<BusRouteInfo> {
+    override suspend fun getSeoulBusRoute(stationId: String): List<SeoulBusRouteInfo> {
         return try {
             remoteDataSource.getSeoulBusRoute(stationId)
         } catch (exception: JsonDataException) {
@@ -146,5 +146,13 @@ internal class RouteRepositoryImpl @Inject constructor(
         } catch (exception: NullPointerException) {
             listOf()
         }
+    }
+
+    override suspend fun getBusRouteInfo(routeName: String): List<BusRouteInfo> {
+        return remoteDataSource.getBusRouteList(routeName)
+    }
+
+    override suspend fun getSeoulBusStations(routeId: String): List<BusStationInfo> {
+        return remoteDataSource.getBusStations(routeId)
     }
 }

--- a/domain/src/main/java/com/stop/domain/model/route/TransportIdRequest.kt
+++ b/domain/src/main/java/com/stop/domain/model/route/TransportIdRequest.kt
@@ -5,7 +5,7 @@ import com.stop.domain.model.route.tmap.custom.Place
 
 data class TransportIdRequest(
     val transportMoveType: TransportMoveType,
-    val stationId: String,
+    val stationNumber: String,
     val stationName: String,
     val coordinate: Coordinate,
     val stationType: Int,
@@ -14,14 +14,14 @@ data class TransportIdRequest(
     val routeName: String,
     val term: Int, // 배차 간격, 서울 버스는 노선을 구하는 과정에서 얻을 수 있기 때문에 넣음
     val destinationStation: Place,
-    val destinationStationId: String,
+    val destinationStationNumber: String,
     val sectionTime: Int,
     val cumulativeSectionTime: Int,
 ) {
-    fun changeStartStationId(newStationId: String): TransportIdRequest {
+    fun changeStartStationId(newStationNumber: String): TransportIdRequest {
         return TransportIdRequest(
             transportMoveType = transportMoveType,
-            stationId = newStationId,
+            stationNumber = newStationNumber,
             stationName = stationName,
             coordinate = coordinate,
             stationType = stationType,
@@ -30,16 +30,16 @@ data class TransportIdRequest(
             routeName = routeName,
             term = term,
             destinationStation = destinationStation,
-            destinationStationId = destinationStationId,
+            destinationStationNumber = destinationStationNumber,
             sectionTime = sectionTime,
             cumulativeSectionTime = cumulativeSectionTime,
         )
     }
 
-    fun changeDestinationStationId(newDestinationStationId: String): TransportIdRequest {
+    fun changeDestinationStationId(newDestinationStationNumber: String): TransportIdRequest {
         return TransportIdRequest(
             transportMoveType = transportMoveType,
-            stationId = stationId,
+            stationNumber = stationNumber,
             stationName = stationName,
             coordinate = coordinate,
             stationType = stationType,
@@ -48,7 +48,7 @@ data class TransportIdRequest(
             routeName = routeName,
             term = term,
             destinationStation = destinationStation,
-            destinationStationId = newDestinationStationId,
+            destinationStationNumber = newDestinationStationNumber,
             sectionTime = sectionTime,
             cumulativeSectionTime = cumulativeSectionTime,
         )
@@ -57,7 +57,7 @@ data class TransportIdRequest(
     fun changeRouteId(newRouteId: String, newTerm: Int?): TransportIdRequest {
         return TransportIdRequest(
             transportMoveType = transportMoveType,
-            stationId = stationId,
+            stationNumber = stationNumber,
             stationName = stationName,
             coordinate = coordinate,
             stationType = stationType,
@@ -66,7 +66,7 @@ data class TransportIdRequest(
             routeName = routeName,
             term = newTerm ?: term,
             destinationStation = destinationStation,
-            destinationStationId = destinationStationId,
+            destinationStationNumber = destinationStationNumber,
             sectionTime = sectionTime,
             cumulativeSectionTime = cumulativeSectionTime,
         )

--- a/domain/src/main/java/com/stop/domain/model/route/TransportMoveType.kt
+++ b/domain/src/main/java/com/stop/domain/model/route/TransportMoveType.kt
@@ -1,12 +1,16 @@
 package com.stop.domain.model.route
 
+import com.stop.domain.model.route.tmap.custom.MoveType
+
 enum class TransportMoveType {
     BUS, SUBWAY;
 
     companion object {
-        fun getMoveTypeByName(name: String): TransportMoveType? {
-            return values().firstOrNull {
-                it.name == name
+        fun from(moveType: MoveType): TransportMoveType? {
+            return when (moveType) {
+                MoveType.BUS -> BUS
+                MoveType.SUBWAY -> SUBWAY
+                else -> null
             }
         }
     }

--- a/domain/src/main/java/com/stop/domain/model/route/seoul/bus/ArsIdMsgBody.kt
+++ b/domain/src/main/java/com/stop/domain/model/route/seoul/bus/ArsIdMsgBody.kt
@@ -6,5 +6,5 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class ArsIdMsgBody(
     @Json(name = "itemList")
-    val busStations: List<BusStationInfo>?
+    val busStations: List<SeoulBusStationInfo>?
 )

--- a/domain/src/main/java/com/stop/domain/model/route/seoul/bus/BusRouteInfo.kt
+++ b/domain/src/main/java/com/stop/domain/model/route/seoul/bus/BusRouteInfo.kt
@@ -1,14 +1,10 @@
 package com.stop.domain.model.route.seoul.bus
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
-
-@JsonClass(generateAdapter = true)
 data class BusRouteInfo(
-    @Json(name = "busRouteNm")
-    val busRouteName: String,
-    @Json(name = "busRouteId")
-    val routeId: String,
-    @Json(name = "term")
-    val term: Int,
+    val busRouteName: String, // 노선명
+    val busRouteAbbreviation : String, // 노선약칭
+    val busRouteId: String, // 노선 번호
+    val term: Int, // 배차간격
+    val corpName: String, // 운수사명
+    val lastBusTime: String, // 막차시간
 )

--- a/domain/src/main/java/com/stop/domain/model/route/seoul/bus/BusStationInfo.kt
+++ b/domain/src/main/java/com/stop/domain/model/route/seoul/bus/BusStationInfo.kt
@@ -1,15 +1,9 @@
 package com.stop.domain.model.route.seoul.bus
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
-
-@JsonClass(generateAdapter = true)
 data class BusStationInfo(
-    val arsId: String,
-    @Json(name = "stNm")
+    val startTime: String,
+    val lastTime: String,
     val stationName: String,
-    @Json(name = "tmX")
-    val longitude: String,
-    @Json(name = "tmY")
-    val latitude: String,
+    val stationId: String, // 정류소 고유 ID station
+    val stationNumber: String, // 정류소 번호 stationNo
 )

--- a/domain/src/main/java/com/stop/domain/model/route/seoul/bus/RouteIdMsgBody.kt
+++ b/domain/src/main/java/com/stop/domain/model/route/seoul/bus/RouteIdMsgBody.kt
@@ -6,5 +6,5 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class RouteIdMsgBody(
     @Json(name = "itemList")
-    val busRoutes: List<BusRouteInfo>?
+    val busRoutes: List<SeoulBusRouteInfo>?
 )

--- a/domain/src/main/java/com/stop/domain/model/route/seoul/bus/SeoulBusRouteInfo.kt
+++ b/domain/src/main/java/com/stop/domain/model/route/seoul/bus/SeoulBusRouteInfo.kt
@@ -1,0 +1,14 @@
+package com.stop.domain.model.route.seoul.bus
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class SeoulBusRouteInfo(
+    @Json(name = "busRouteNm")
+    val busRouteName: String,
+    @Json(name = "busRouteId")
+    val routeId: String,
+    @Json(name = "term")
+    val term: Int,
+)

--- a/domain/src/main/java/com/stop/domain/model/route/seoul/bus/SeoulBusStationInfo.kt
+++ b/domain/src/main/java/com/stop/domain/model/route/seoul/bus/SeoulBusStationInfo.kt
@@ -1,0 +1,15 @@
+package com.stop.domain.model.route.seoul.bus
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class SeoulBusStationInfo(
+    val arsId: String,
+    @Json(name = "stNm")
+    val stationName: String,
+    @Json(name = "tmX")
+    val longitude: String,
+    @Json(name = "tmY")
+    val latitude: String,
+)

--- a/domain/src/main/java/com/stop/domain/model/route/seoul/subway/StationType.kt
+++ b/domain/src/main/java/com/stop/domain/model/route/seoul/subway/StationType.kt
@@ -1,0 +1,30 @@
+package com.stop.domain.model.route.seoul.subway
+
+/**
+ *
+ * @param type T MAP 대중교통 API에서 사용하는 이동수단 노선 코드
+ * @param lineName 공공데이터포털에서 사용하는 호선명
+ */
+enum class StationType(val type: Int, val lineName: String) {
+    ONE(1, "01호선"),
+    TWO(2, "02호선"),
+    THREE(3, "03호선"),
+    FOUR(4, "04호선"),
+    FIVE(5, "05호선"),
+    SIX(6, "06호선"),
+    SEVEN(7, "07호선"),
+    EIGHT(8, "08호선"),
+    NINE(9, "09호선"),
+    GYEONG_GANG(112, "경강선"),
+    GYEONGUI_JUNGANG(112, "경의선"), // 경의중앙선
+    SHINBUNDANG(109, "신분당선");
+
+    companion object {
+        // 22년 11월 기준, 공공데이터 포털에서 1 ~ 8호선에 속한 지하철 역의 막차 시간만 제공합니다.
+        val allowedStationType = hashSetOf(ONE, TWO, THREE, FOUR, FIVE, SIX, SEVEN, EIGHT)
+
+        fun from(type: Int): StationType? {
+            return entries.firstOrNull { it.type == type }
+        }
+    }
+}

--- a/domain/src/main/java/com/stop/domain/model/route/tmap/custom/MoveType.kt
+++ b/domain/src/main/java/com/stop/domain/model/route/tmap/custom/MoveType.kt
@@ -7,7 +7,7 @@ enum class MoveType {
         private const val NO_MATCHING_VALUE = "해당 변수 값이 없습니다."
 
         fun getMoveTypeByName(name: String): MoveType {
-            return values().firstOrNull {
+            return entries.firstOrNull {
                     it.name == name
                 } ?: throw IllegalArgumentException(NO_MATCHING_VALUE)
         }

--- a/domain/src/main/java/com/stop/domain/model/route/tmap/custom/Route.kt
+++ b/domain/src/main/java/com/stop/domain/model/route/tmap/custom/Route.kt
@@ -1,6 +1,6 @@
 package com.stop.domain.model.route.tmap.custom
 
-interface Route {
+sealed interface Route {
     val distance: Double
     val end: Place
     val mode: MoveType

--- a/domain/src/main/java/com/stop/domain/repository/RouteRepository.kt
+++ b/domain/src/main/java/com/stop/domain/repository/RouteRepository.kt
@@ -28,8 +28,8 @@ interface RouteRepository {
         weekType: WeekType,
     ): List<StationLastTime>
 
-    suspend fun getSeoulBusStationArsId(stationName: String): List<BusStationInfo>
-    suspend fun getSeoulBusRoute(stationId: String): List<BusRouteInfo>
+    suspend fun getSeoulBusStationArsId(stationName: String): List<SeoulBusStationInfo>
+    suspend fun getSeoulBusRoute(stationId: String): List<SeoulBusRouteInfo>
     suspend fun getSeoulBusLastTime(stationId: String, lineId: String): List<LastTimeInfo>
     suspend fun getSubwayRoute(
         routeRequest: RouteRequest,
@@ -42,4 +42,6 @@ interface RouteRepository {
     suspend fun getGyeonggiBusRoute(stationId: String): List<GyeonggiBusRoute>
     suspend fun getGyeonggiBusLastTime(lineId: String): List<GyeonggiBusLastTime>
     suspend fun getGyeonggiBusRouteStations(lineId: String): List<GyeonggiBusStation>
+    suspend fun getBusRouteInfo(routeName: String): List<BusRouteInfo>
+    suspend fun getSeoulBusStations(routeId: String): List<BusStationInfo>
 }

--- a/domain/src/main/java/com/stop/domain/repository/RouteRepository.kt
+++ b/domain/src/main/java/com/stop/domain/repository/RouteRepository.kt
@@ -8,6 +8,7 @@ import com.stop.domain.model.route.gyeonggi.GyeonggiBusStation
 import com.stop.domain.model.route.seoul.bus.*
 import com.stop.domain.model.route.seoul.subway.Station
 import com.stop.domain.model.route.seoul.subway.StationLastTime
+import com.stop.domain.model.route.seoul.subway.StationType
 import com.stop.domain.model.route.seoul.subway.TransportDirectionType
 import com.stop.domain.model.route.seoul.subway.WeekType
 import com.stop.domain.model.route.tmap.RouteRequest
@@ -20,7 +21,7 @@ interface RouteRepository {
     suspend fun getRoute(routeRequest: RouteRequest): List<Itinerary>
     suspend fun reverseGeocoding(coordinate: Coordinate, addressType: AddressType): ReverseGeocodingResponse
 
-    suspend fun getSubwayStationCd(stationId: String, stationName: String): String
+    suspend fun getSubwayStationCd(stationType: StationType, stationName: String): String
     suspend fun getSubwayStations(lineName: String): List<Station>
     suspend fun getSubwayStationLastTime(
         stationId: String,

--- a/domain/src/main/java/com/stop/domain/usecase/route/GetLastTransportTimeUseCaseImpl.kt
+++ b/domain/src/main/java/com/stop/domain/usecase/route/GetLastTransportTimeUseCaseImpl.kt
@@ -3,7 +3,7 @@ package com.stop.domain.usecase.route
 import com.stop.domain.model.geoLocation.AddressType
 import com.stop.domain.model.route.*
 import com.stop.domain.model.route.gyeonggi.GyeonggiBusStation
-import com.stop.domain.model.route.seoul.bus.BusStationInfo
+import com.stop.domain.model.route.seoul.bus.SeoulBusStationInfo
 import com.stop.domain.model.route.seoul.subway.Station
 import com.stop.domain.model.route.seoul.subway.TransportDirectionType
 import com.stop.domain.model.route.seoul.subway.WeekType
@@ -19,11 +19,11 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
     private val allowedSubwayLineForUse = (SUBWAY_LINE_ONE..SUBWAY_LINE_EIGHT)
 
     override suspend operator fun invoke(itinerary: Itinerary): List<TransportLastTime?> {
-        var transportIdRequests: List<TransportIdRequest?> = createTransportIdRequests(itinerary)
-        transportIdRequests = convertStationId(transportIdRequests)
-        transportIdRequests = convertRouteId(transportIdRequests)
+        var requests: List<TransportIdRequest?> = createTransportIdRequests(itinerary)
+        requests = convertStationId(requests)
+        requests = convertRouteId(requests)
 
-        return getLastTransportTime(transportIdRequests)
+        return getLastTransportTime(requests)
     }
 
     private suspend fun getLastTransportTime(transportIdRequests: List<TransportIdRequest?>): List<TransportLastTime?> {
@@ -66,6 +66,7 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
                             Area.UN_SUPPORT_AREA -> throw NoServiceAreaException()
                         }
                     }
+
                     TransportMoveType.SUBWAY -> transportIdRequest
                 }
             } catch (exception: NoAppropriateDataException) {
@@ -107,7 +108,7 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
             throw NoAppropriateDataException("API를 지원하지 않는 전철역입니다.")
         }
         val stationCd = routeRepository.getSubwayStationCd(
-            transportIdRequest.stationId,
+            transportIdRequest.stationNumber,
             transportIdRequest.stationName
         )
 
@@ -124,18 +125,22 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
 
         return itinerary.routes.fold(listOf()) { transportIdRequests, route ->
             when (route) {
-                is WalkRoute -> transportIdRequests + null
-                is TransportRoute -> {
-                    val startStation = route.stations.first()
-                    val transportMoveType = TransportMoveType.getMoveTypeByName(route.mode.name)
-                        ?: return@fold transportIdRequests
+                is WalkRoute -> {
+                    cumulativeSectionTime += route.sectionTime.toInt()
+                    transportIdRequests + null
+                }
 
+                is TransportRoute -> {
                     val sectionTime = route.sectionTime.toInt()
                     cumulativeSectionTime += sectionTime
 
+                    val startStation = route.stations.first()
+                    val transportMoveType =
+                        TransportMoveType.from(route.mode) ?: return@fold transportIdRequests
+
                     transportIdRequests + TransportIdRequest(
                         transportMoveType = transportMoveType,
-                        stationId = startStation.stationId,
+                        stationNumber = startStation.stationId,
                         stationName = startStation.stationName,
                         coordinate = startStation.coordinate,
                         stationType = route.routeType,
@@ -144,12 +149,11 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
                         routeId = UNKNOWN_ID,
                         term = NOT_YET_CALCULATED,
                         destinationStation = route.end,
-                        destinationStationId = UNKNOWN_ID,
+                        destinationStationNumber = UNKNOWN_ID,
                         sectionTime = sectionTime,
                         cumulativeSectionTime = cumulativeSectionTime,
                     )
                 }
-                else -> transportIdRequests + null
             }
         }
     }
@@ -158,7 +162,7 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
         transportIdRequest: TransportIdRequest
     ): TransportIdRequest {
         val busName = transportIdRequest.routeName.split(":")[1]
-        val routes = routeRepository.getGyeonggiBusRoute(transportIdRequest.stationId)
+        val routes = routeRepository.getGyeonggiBusRoute(transportIdRequest.stationNumber)
 
         if (routes.isEmpty()) {
             throw ApiServerDataException()
@@ -217,7 +221,7 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
         }
 
         val lastTrainTime = routeRepository.getSubwayStationLastTime(
-            transportIdRequest.stationId,
+            transportIdRequest.stationNumber,
             subwayCircleType,
             weekType
         )
@@ -364,21 +368,18 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
     private suspend fun getSeoulBusLastTransportTime(
         transportIdRequest: TransportIdRequest
     ): TransportLastTime {
-        val lastTimes = routeRepository.getSeoulBusLastTime(
-            transportIdRequest.stationId,
-            transportIdRequest.routeId
-        )
-        if (lastTimes.isEmpty()) {
-            return getRectifiedGyeonggiBusLastTransportTime(transportIdRequest)
-        }
+        val stations = routeRepository.getSeoulBusStations(transportIdRequest.routeId)
+            .filter { it.stationName.contains(transportIdRequest.stationName) }
 
-        var lastTime = lastTimes.first().lastTime?.toInt() ?: throw ApiServerDataException()
+        var lastTime = stations.firstOrNull {
+            it.stationNumber == transportIdRequest.stationNumber
+        }?.lastTime?.replace(":", "")?.toInt() ?: return getRectifiedGyeonggiBusLastTransportTime(transportIdRequest)
 
         if (lastTime < MID_NIGHT) {
             lastTime += TIME_CORRECTION_VALUE
         }
 
-        val lastTimeString = lastTime.toString().padStart(6, '0').chunked(2).joinToString(":")
+        val lastTimeString = lastTime.toString().padEnd(6, '0').chunked(2).joinToString(":")
 
         return TransportLastTime(
             transportMoveType = TransportMoveType.BUS,
@@ -507,7 +508,7 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
         newTransportIdRequest = convertSeoulBusRouteId(newTransportIdRequest)
 
         val lastTimes = routeRepository.getSeoulBusLastTime(
-            newTransportIdRequest.stationId,
+            newTransportIdRequest.stationNumber,
             newTransportIdRequest.routeId
         )
 
@@ -566,9 +567,9 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
         for ((index, station) in stations.withIndex()) {
             val stationId = station.stationId.toString()
 
-            if (stationId == transportIdRequest.stationId) {
+            if (stationId == transportIdRequest.stationNumber) {
                 startIndex = index
-            } else if (stationId == transportIdRequest.destinationStationId) {
+            } else if (stationId == transportIdRequest.destinationStationNumber) {
                 endIndex = index
             }
 
@@ -591,7 +592,7 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
         transportIdRequest: TransportIdRequest
     ): TransportIdRequest {
         val busName = transportIdRequest.routeName.split(":")[1]
-        val busRouteInfo = routeRepository.getSeoulBusRoute(transportIdRequest.stationId)
+        val busRouteInfo = routeRepository.getBusRouteInfo(busName)
 
         if (busRouteInfo.isEmpty()) {
             throw ApiServerDataException()
@@ -601,7 +602,7 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
             it.busRouteName.contains(busName)
         } ?: throw NoAppropriateDataException("버스 노선 고유 아이디가 없습니다.")
 
-        return transportIdRequest.changeRouteId(route.routeId, route.term)
+        return transportIdRequest.changeRouteId(route.busRouteId, route.term)
     }
 
     private suspend fun getArea(coordinate: Coordinate): Area {
@@ -693,11 +694,11 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
 
     private fun findClosestSeoulBusStation(
         transportIdRequest: TransportIdRequest,
-        busStations: List<BusStationInfo>,
+        busStations: List<SeoulBusStationInfo>,
     ): String {
         val originLongitude = correctLongitudeValue(transportIdRequest.coordinate.longitude)
         val originLatitude = correctLatitudeValue(transportIdRequest.coordinate.latitude)
-        var closestStation: BusStationInfo? = null
+        var closestStation: SeoulBusStationInfo? = null
         var closestDistance = 0.0
 
         busStations.filter {
@@ -771,7 +772,7 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
         private const val NOT_YET_CALCULATED = 0
         private const val KOREA_LONGITUDE = 127
         private const val KOREA_LATITUDE = 37
-        private const val CORRECTION_VALUE = 100_000
+        private const val CORRECTION_VALUE = 1_000_000
         private const val TIME_DIGIT = 2
 
         private const val EMPIRICAL_DISTINCTION = 20
@@ -779,8 +780,8 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
         private const val SUBWAY_LINE_ONE = 1
         private const val SUBWAY_LINE_EIGHT = 8
 
-        private const val MID_NIGHT = 60_000
-        private const val TIME_CORRECTION_VALUE = 240_000
+        private const val MID_NIGHT = 600
+        private const val TIME_CORRECTION_VALUE = 2400
     }
 }
 

--- a/domain/src/main/java/com/stop/domain/usecase/route/GetLastTransportTimeUseCaseImpl.kt
+++ b/domain/src/main/java/com/stop/domain/usecase/route/GetLastTransportTimeUseCaseImpl.kt
@@ -131,6 +131,7 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
 
                 is TransportRoute -> {
                     val sectionTime = route.sectionTime.toInt()
+                    val currentCumulativeSectionTime = cumulativeSectionTime
                     cumulativeSectionTime += sectionTime
 
                     val startStation = route.stations.first()
@@ -150,7 +151,7 @@ internal class GetLastTransportTimeUseCaseImpl @Inject constructor(
                         destinationStation = route.end,
                         destinationStationNumber = UNKNOWN_ID,
                         sectionTime = sectionTime,
-                        cumulativeSectionTime = cumulativeSectionTime,
+                        cumulativeSectionTime = currentCumulativeSectionTime,
                     )
                 }
             }


### PR DESCRIPTION
## 버스 API

- 기존에 막차 시간을 잘못 계산하고 있던 로직 수정
- 서울특별시_노선정보조회 서비스 API를 이용해 서울시와 경기도 노선 정보 조회 로직을 통합하려고 했으나, 일부 경기도 버스는 정보가 조회되지 않아, 서울시 버스 막차 시간 계산에만 활용하도록 적용

## 지하철 API

- 지하철 막차 시간 조회를 위한 데이터 전처리 로직 수정

## tikxml ksp 미지원 

경기도 API는 XML로 데이터를 보내주고 있어, tikxml라는 라이브러리를 이용해 데이터 클래스로 변환하고 있다.
분명히 이전에 잘 파싱된 것을 확인했는데, 저번 주부터 XML 데이터를 파싱하지 못하는 문제가 발생했다.
라이브러리 문제라고 생각해서 JaxB도 찾아보고, SimpleXML도 찾아봤지만, 변환이 잘 되지 않았다.

그래서 다시 tikxml를 사용하도록 롤백했다. 에러 문구를 다시 천천히 확인해보니 TypeAdapter가 생성되지 않았다는 말이 있었다.

> com.tickaroo.tikxml.TypeAdapterNotFoundException: No TypeAdapter for class com.stop.data.remote.model.route.gyeonggi.GyeonggiBusStationIdResponse found. Expected name of the type adapter is

Converter에 의해 Adapter가 자동 생성되어야 하는데, 되지 않았다는 것은 애노테이션과 관련된 문제라는 생각이 들어서 해당 라이브러리 문서를 찾아보니 Type Converter를 커스텀으로 직접 구현하는 부분에 대한 설명이 있었다.

https://github.com/Tickaroo/tikxml/blob/master/docs/AnnotatingModelClasses.md#type-converter

하지만... 직접 Adapter를 구현한다면 라이브러리를 사용하는 의미가 없다는 생각이 들어서 만들지는 않았다.
애노테이션 관련해서 변경한 부분이 무엇이 있을까 생각해보니 빌드 관련 설정을 바꿀 때 모두 ksp로 변경했었다.
그래서 kapt로 바꿔봤는데, 잘 동작한다.....

이 문제를 해결하기 위해 10시간 이상은 소비한 것 같은데... 너무 허무하다.

배운점이 있다면, 무조건 적인 마이그레이션은 피해야겠다는 점이다. 공식 문서에서 ksp로 변환하라는 글을 보고 바꿨던 건데, 이것이 문제가 될 줄은 몰랐다.

https://developer.android.com/build/migrate-to-ksp

공식 문서 설명에도 라이브러리가 KSP를 지원하는지 확인하라고 첫 문단에 Bold로 적어뒀지만, tikxml는 공식 라이브러리가 아니라는 생각에 안일하게 넘어갔던 것 같다....

해당 라이브러리가 KSP를 지원하도록 오픈 소스 기여를 하고 싶지만, 내 실력을 벗어나는 작업이고, 아직 취준 중이기 때문에 시간이 없다...

그래서 Issue에 지원을 부탁하는 글만 남겼다.

https://github.com/Tickaroo/tikxml/issues/160