### PR TITLE
경로 검색 결과 화면 성능 개선

### DIFF
--- a/presentation/src/main/java/com/stop/model/route/ItineraryInfo.kt
+++ b/presentation/src/main/java/com/stop/model/route/ItineraryInfo.kt
@@ -1,0 +1,8 @@
+package com.stop.model.route
+
+data class ItineraryInfo(
+    val totalDistance: Double, // 총 이동 거리
+    val minuteOfTotalTime: Int, // 소요 시간 - 분
+    val hourOfTotalTime: Int, // 소요 시간 - 시
+    val routeInfo: List<RouteInfo>, // 경유지 정보
+)

--- a/presentation/src/main/java/com/stop/model/route/RouteInfo.kt
+++ b/presentation/src/main/java/com/stop/model/route/RouteInfo.kt
@@ -1,0 +1,14 @@
+package com.stop.model.route
+
+import androidx.annotation.DrawableRes
+import com.stop.domain.model.route.tmap.custom.MoveType
+
+data class RouteInfo(
+    val mode: MoveType, // 이동 방법
+    val sectionTime: Double, // 소요된 시간(초 단위)
+    val proportionOfSectionTime: Float, // 전체 소요 시간 중 현재 경로가 차지하는 비율
+    val typeName: String, // 해당 구간 타입 정보 ex) 지하철은 호선, 버스는 노선 번호, 도보는 하차
+    val stationName: String, // 역 또는 정류소 이름
+    val symbolColor: Int, // 대중교통은 해당 노선 고유 색상, 도보는 회색으로 처리
+    @DrawableRes val symbolDrawableId: Int, // 이동 수단을 나타내는 리소스 아이디
+)

--- a/presentation/src/main/java/com/stop/ui/route/OnItineraryClickListener.kt
+++ b/presentation/src/main/java/com/stop/ui/route/OnItineraryClickListener.kt
@@ -1,9 +1,9 @@
 package com.stop.ui.route
 
-import com.stop.domain.model.route.tmap.custom.Itinerary
+import com.stop.model.route.ItineraryInfo
 
 interface OnItineraryClickListener {
 
-    fun onItineraryClick(itinerary: Itinerary)
+    fun onItineraryClick(itineraryInfo: ItineraryInfo)
 
 }

--- a/presentation/src/main/java/com/stop/ui/route/RouteAdapter.kt
+++ b/presentation/src/main/java/com/stop/ui/route/RouteAdapter.kt
@@ -34,6 +34,11 @@ class RouteAdapter(
         holder.bind(getItem(position))
     }
 
+    override fun onViewRecycled(holder: RouteViewHolder) {
+        holder.recycle()
+    }
+
+
     companion object {
         private val diffUtil = object : DiffUtil.ItemCallback<ItineraryInfo>() {
             override fun areItemsTheSame(

--- a/presentation/src/main/java/com/stop/ui/route/RouteAdapter.kt
+++ b/presentation/src/main/java/com/stop/ui/route/RouteAdapter.kt
@@ -6,11 +6,11 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.stop.databinding.ItemRouteBinding
-import com.stop.domain.model.route.tmap.custom.Itinerary
+import com.stop.model.route.ItineraryInfo
 
 class RouteAdapter(
     private val onItineraryClickListener: OnItineraryClickListener
-) : ListAdapter<Itinerary, RouteViewHolder>(diffUtil) {
+) : ListAdapter<ItineraryInfo, RouteViewHolder>(diffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RouteViewHolder {
         val binding = ItemRouteBinding.inflate(
@@ -35,17 +35,17 @@ class RouteAdapter(
     }
 
     companion object {
-        private val diffUtil = object : DiffUtil.ItemCallback<Itinerary>() {
+        private val diffUtil = object : DiffUtil.ItemCallback<ItineraryInfo>() {
             override fun areItemsTheSame(
-                oldItinerary: Itinerary,
-                newItinerary: Itinerary
+                oldItinerary: ItineraryInfo,
+                newItinerary: ItineraryInfo
             ): Boolean {
                 return oldItinerary.totalDistance == newItinerary.totalDistance
             }
 
             override fun areContentsTheSame(
-                oldItinerary: Itinerary,
-                newItinerary: Itinerary
+                oldItinerary: ItineraryInfo,
+                newItinerary: ItineraryInfo
             ): Boolean {
                 return oldItinerary == newItinerary
             }

--- a/presentation/src/main/java/com/stop/ui/route/RouteFragment.kt
+++ b/presentation/src/main/java/com/stop/ui/route/RouteFragment.kt
@@ -17,7 +17,7 @@ import androidx.navigation.fragment.navArgs
 import androidx.navigation.navGraphViewModels
 import com.stop.R
 import com.stop.databinding.FragmentRouteBinding
-import com.stop.domain.model.route.tmap.custom.Itinerary
+import com.stop.model.route.ItineraryInfo
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -103,10 +103,9 @@ class RouteFragment : Fragment() {
 
     private fun setRecyclerView() {
         adapter = RouteAdapter(object : OnItineraryClickListener {
-            override fun onItineraryClick(itinerary: Itinerary) {
+            override fun onItineraryClick(itineraryInfo: ItineraryInfo) {
                 alertDialog.show()
-                routeViewModel.calculateLastTransportTime(itinerary)
-                routeResultViewModel.setItineraries(itinerary)
+                routeViewModel.calculateLastTransportTime(itineraryInfo)
             }
         })
         binding.recyclerviewRoute.adapter = adapter
@@ -160,11 +159,17 @@ class RouteFragment : Fragment() {
             }
             binding.textViewOrigin.setTextColor(ContextCompat.getColor(this.requireContext(), R.color.main_dark_grey))
         }
-        routeViewModel.routeResponse.observe(viewLifecycleOwner) {
-            if (it == null) {
-                return@observe
-            }
+//        routeViewModel.routeResponse.observe(viewLifecycleOwner) {
+//            if (it == null) {
+//                return@observe
+//            }
+//            adapter.submitList(it)
+//        }
+        routeViewModel.itineraryInfo.observe(viewLifecycleOwner) {
             adapter.submitList(it)
+        }
+        routeViewModel.selectedItinerary.observe(viewLifecycleOwner) {
+            routeResultViewModel.setItineraries(it)
         }
 
         routeViewModel.errorMessage.observe(viewLifecycleOwner) {

--- a/presentation/src/main/java/com/stop/ui/route/RouteViewHolder.kt
+++ b/presentation/src/main/java/com/stop/ui/route/RouteViewHolder.kt
@@ -1,128 +1,28 @@
 package com.stop.ui.route
 
-import android.graphics.Color
 import android.view.View
-import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
-import com.stop.R
 import com.stop.databinding.ItemRouteBinding
-import com.stop.domain.model.route.tmap.custom.*
-import com.stop.model.route.RouteItem
-import com.stop.model.route.RouteItemType
+import com.stop.model.route.ItineraryInfo
 
 class RouteViewHolder(
     private val binding: ItemRouteBinding
 ) : RecyclerView.ViewHolder(binding.root) {
 
-    private var routeItemColor = 0
+    fun bind(itineraryInfo: ItineraryInfo) {
 
-    fun bind(itinerary: Itinerary) {
-        setRequireTime(itinerary.totalTime)
-        val routeItems = mutableListOf<RouteItem>()
-
-        itinerary.routes.drop(1).forEachIndexed { index, route ->
-            if (route.mode == MoveType.TRANSFER) {
-                return@forEachIndexed
-            }
-            val (typeName, mode) = if (index == itinerary.routes.size - 2) {
-                Pair("하차", R.drawable.ic_star_white)
-            } else {
-                Pair(getTypeName(route), getRouteItemMode(route))
-            }
-
-            routeItems.add(
-                RouteItem(
-                    name = route.start.name,
-                    coordinate = route.start.coordinate,
-                    mode = mode,
-                    distance = getRouteItemDistance(route),
-                    travelTime = route.sectionTime.toInt(),
-                    lastTime = "",
-                    beforeColor = getRouteItemColor(route, false),
-                    currentColor = getRouteItemColor(route, true),
-                    type = RouteItemType.PATH,
-                    typeName = typeName,
-                )
-            )
-        }
-        binding.stationContainer.removeAllViewsInLayout()
-
-        binding.timeLineContainer.removeAllViewsInLayout()
-
-        binding.stationContainer.submitList(routeItems.toList())
-        binding.timeLineContainer.submitList(itinerary.routes)
-    }
-
-    private fun getRouteItemDistance(route: Route): Double {
-        return if (route.mode == MoveType.TRANSFER) {
-            val startPoint = android.location.Location("Start")
-            val endPoint = android.location.Location("End")
-
-            startPoint.latitude = route.start.coordinate.latitude.toDouble()
-            startPoint.longitude = route.start.coordinate.longitude.toDouble()
-            endPoint.latitude = route.end.coordinate.latitude.toDouble()
-            endPoint.longitude = route.end.coordinate.longitude.toDouble()
-            startPoint.distanceTo(endPoint).toDouble()
-        } else {
-            route.distance
-        }
-    }
-
-    private fun getTypeName(route: Route): String {
-        return when (route) {
-            is WalkRoute -> "도보"
-            is TransportRoute -> getSubwayTypeName(route)
-            else -> ""
-        }
-    }
-
-    private fun getSubwayTypeName(route: TransportRoute): String {
-        return when (route.mode) {
-            MoveType.SUBWAY -> route.routeInfo.replace("수도권", "")
-            MoveType.BUS -> route.routeInfo.split(":")[1]
-            else -> route.routeInfo
-        }
-    }
-
-    private fun getRouteItemColor(route: Route, isCurrent: Boolean): Int {
-        return if (isCurrent) {
-            routeItemColor = when (route) {
-                is TransportRoute -> Color.parseColor("#${route.routeColor}")
-                is WalkRoute -> ContextCompat.getColor(binding.root.context, R.color.main_yellow)
-                else -> ContextCompat.getColor(binding.root.context, R.color.main_lighter_grey)
-            }
-            routeItemColor
-        } else {
-            if (routeItemColor != 0) {
-                routeItemColor
-            } else {
-                getRouteItemColor(route, true)
-            }
-        }
-    }
-
-    private fun getRouteItemMode(route: Route): Int {
-        return when (route.mode) {
-            MoveType.WALK, MoveType.TRANSFER -> R.drawable.ic_walk_white
-            MoveType.BUS -> R.drawable.ic_bus_white
-            MoveType.SUBWAY -> R.drawable.ic_subway_white
-            else -> R.drawable.ic_star_white
-        }
-    }
-
-    private fun setRequireTime(second: Int) {
-        val hour = second / 60 / 60
-        val minute = second / 60 % 60
-        if (hour != 0) {
+        if (itineraryInfo.hourOfTotalTime != 0) {
             binding.textViewRequiredHour.visibility = View.VISIBLE
             binding.textViewRequiredHourText.visibility = View.VISIBLE
-            binding.textViewRequiredHour.text = hour.toString()
+            binding.textViewRequiredHour.text = itineraryInfo.hourOfTotalTime.toString()
         } else {
             binding.textViewRequiredHour.visibility = View.GONE
             binding.textViewRequiredHourText.visibility = View.GONE
         }
 
-        binding.textViewRequiredMinute.text = minute.toString()
-    }
+        binding.textViewRequiredMinute.text = itineraryInfo.minuteOfTotalTime.toString()
 
+        binding.stationContainer.submitList(itineraryInfo.routeInfo)
+        binding.timeLineContainer.submitList(itineraryInfo.routeInfo)
+    }
 }

--- a/presentation/src/main/java/com/stop/ui/route/RouteViewHolder.kt
+++ b/presentation/src/main/java/com/stop/ui/route/RouteViewHolder.kt
@@ -25,4 +25,9 @@ class RouteViewHolder(
         binding.stationContainer.submitList(itineraryInfo.routeInfo)
         binding.timeLineContainer.submitList(itineraryInfo.routeInfo)
     }
+
+    fun recycle() {
+        binding.timeLineContainer.doRecycle()
+        binding.stationContainer.doRecycle()
+    }
 }

--- a/presentation/src/main/java/com/stop/ui/route/StationContainer.kt
+++ b/presentation/src/main/java/com/stop/ui/route/StationContainer.kt
@@ -7,10 +7,8 @@ import android.view.LayoutInflater
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
-import androidx.core.content.ContextCompat
-import androidx.core.widget.ImageViewCompat
-import com.stop.databinding.ItemStationContainerBinding
-import com.stop.model.route.RouteItem
+import com.stop.databinding.ItemRouteStationBinding
+import com.stop.model.route.RouteInfo
 
 class StationContainer(
     context: Context,
@@ -19,10 +17,13 @@ class StationContainer(
 
     private var beforeViewId: Int? = null
 
-    fun submitList(routeItems: List<RouteItem>) {
+    fun submitList(routeInfoList: List<RouteInfo>) {
         clearBeforeData()
-        routeItems.forEachIndexed { index, routeItem ->
-            val stationContainerItemBinding = ItemStationContainerBinding.inflate(
+        routeInfoList.forEachIndexed { index, routeInfo ->
+            if (routeInfo.stationName == "출발지") {
+                return@forEachIndexed
+            }
+            val binding = ItemRouteStationBinding.inflate(
                 LayoutInflater.from(context),
                 this,
                 true,
@@ -30,41 +31,40 @@ class StationContainer(
                 root.id = View.generateViewId()
             }
 
-            setBindingAttribute(stationContainerItemBinding, routeItem, index)
-            setConstraint(stationContainerItemBinding)
+            setBindingAttribute(binding, routeInfo, index)
+            setConstraint(binding)
         }
     }
 
     private fun clearBeforeData() {
+        removeAllViewsInLayout()
         beforeViewId = null
     }
 
     private fun setBindingAttribute(
-        binding: ItemStationContainerBinding,
-        routeItem: RouteItem,
+        binding: ItemRouteStationBinding,
+        routeInfo: RouteInfo,
         index: Int
     ) {
-        binding.textViewTypeName.text = routeItem.typeName
-        binding.textViewName.text = routeItem.name
-        binding.viewBeforeLine.setBackgroundColor(routeItem.beforeColor)
-        binding.viewCurrentLine.setBackgroundColor(routeItem.currentColor)
-        ImageViewCompat.setImageTintList(binding.imageViewCurrentLine, ColorStateList.valueOf(routeItem.currentColor))
-        binding.imageViewMode.setImageResource(routeItem.mode)
+        binding.tvTypeName.text = routeInfo.typeName
+        binding.tvLocation.text = routeInfo.stationName
+        binding.ivTypeIcon.imageTintList = ColorStateList.valueOf(routeInfo.symbolColor)
+        binding.tvTypeName.setTextColor(routeInfo.symbolColor)
+        binding.ivTypeIcon.setImageResource(routeInfo.symbolDrawableId)
 
-        if (routeItem.typeName == "하차") {
-            binding.viewLine.visibility = View.GONE
-            binding.viewCurrentLine.visibility = View.GONE
+        if (routeInfo.typeName == "하차") {
+            binding.vBottomVerticalLine.visibility = View.GONE
         } else {
-            binding.viewLine.visibility = View.VISIBLE
-            binding.viewCurrentLine.visibility = View.VISIBLE
+            binding.vBottomVerticalLine.visibility = View.VISIBLE
         }
 
-        if (index == 0) {
-            binding.viewBeforeLine.visibility = View.INVISIBLE
+        if (index == 1) {
+            binding.vTopVerticalLine.visibility = View.INVISIBLE
         }
+
     }
 
-    private fun setConstraint(binding: ItemStationContainerBinding) {
+    private fun setConstraint(binding: ItemRouteStationBinding) {
         val endId = beforeViewId ?: this.id
         val endSide = if (beforeViewId == null) {
             ConstraintSet.TOP

--- a/presentation/src/main/java/com/stop/ui/route/StationContainer.kt
+++ b/presentation/src/main/java/com/stop/ui/route/StationContainer.kt
@@ -16,29 +16,35 @@ class StationContainer(
 ) : ConstraintLayout(context, attrs) {
 
     private var beforeViewId: Int? = null
+    private val bindings = mutableListOf<ItemRouteStationBinding>()
+
+    fun doRecycle() {
+        beforeViewId = null
+        for (binding in bindings) {
+            StationViewPool.putRecycledView(binding)
+            removeView(binding.root)
+        }
+        bindings.clear()
+    }
 
     fun submitList(routeInfoList: List<RouteInfo>) {
-        clearBeforeData()
         routeInfoList.forEachIndexed { index, routeInfo ->
             if (routeInfo.stationName == "출발지") {
                 return@forEachIndexed
             }
-            val binding = ItemRouteStationBinding.inflate(
+            val binding = StationViewPool.getRecycledView() ?: ItemRouteStationBinding.inflate(
                 LayoutInflater.from(context),
                 this,
-                true,
+                false,
             ).apply {
                 root.id = View.generateViewId()
             }
 
+            addView(binding.root)
+            bindings.add(binding)
             setBindingAttribute(binding, routeInfo, index)
             setConstraint(binding)
         }
-    }
-
-    private fun clearBeforeData() {
-        removeAllViewsInLayout()
-        beforeViewId = null
     }
 
     private fun setBindingAttribute(

--- a/presentation/src/main/java/com/stop/ui/route/StationViewPool.kt
+++ b/presentation/src/main/java/com/stop/ui/route/StationViewPool.kt
@@ -1,0 +1,15 @@
+package com.stop.ui.route
+
+import com.stop.databinding.ItemRouteStationBinding
+
+object StationViewPool {
+    private val views = ArrayList<ItemRouteStationBinding>()
+
+    fun getRecycledView(): ItemRouteStationBinding? {
+        return views.removeLastOrNull()
+    }
+
+    fun putRecycledView(view: ItemRouteStationBinding) {
+        views.add(view)
+    }
+}

--- a/presentation/src/main/java/com/stop/ui/route/TimeLineContainer.kt
+++ b/presentation/src/main/java/com/stop/ui/route/TimeLineContainer.kt
@@ -12,8 +12,7 @@ import androidx.core.content.ContextCompat
 import com.stop.R
 import com.stop.databinding.ItemTimeLineBinding
 import com.stop.domain.model.route.tmap.custom.MoveType
-import com.stop.domain.model.route.tmap.custom.Route
-import com.stop.domain.model.route.tmap.custom.TransportRoute
+import com.stop.model.route.RouteInfo
 import kotlin.properties.Delegates
 
 class TimeLineContainer(
@@ -21,7 +20,7 @@ class TimeLineContainer(
     attrs: AttributeSet? = null,
 ) : ConstraintLayout(context, attrs) {
 
-    private val greyColor = ContextCompat.getColor(context, R.color.grey_for_route_walk)
+    private val walkColor = ContextCompat.getColor(context, R.color.grey_for_route_walk)
     private val density = context.resources.displayMetrics.density
 
     private var beforeViewId: Int? = null
@@ -29,7 +28,7 @@ class TimeLineContainer(
     private var routeCount by Delegates.notNull<Int>()
     private var overlappingWidth by Delegates.notNull<Int>()
 
-    fun submitList(routes: List<Route>) {
+    fun submitList(routes: List<RouteInfo>) {
         clearBeforeData()
 
         routeCount = routes.size
@@ -56,11 +55,12 @@ class TimeLineContainer(
     }
 
     private fun clearBeforeData() {
+        removeAllViewsInLayout()
         beforeViewId = null
         beforeView = null
     }
 
-    private fun setBindingAttribute(binding: ItemTimeLineBinding, route: Route, index: Int) {
+    private fun setBindingAttribute(binding: ItemTimeLineBinding, route: RouteInfo, index: Int) {
         val filterTime = if (routeCount < 7) {
             60.0
         } else {
@@ -87,7 +87,7 @@ class TimeLineContainer(
             MoveType.SUBWAY -> R.drawable.time_line_subway_16
             MoveType.WALK, MoveType.TRANSFER -> {
                 if (index != 0) {
-                    setDefaultColor(binding)
+                    setIdentityColor(binding, route)
                     binding.viewIcon.visibility = View.GONE
                     binding.imageViewIcon.visibility = View.GONE
                     setConstraint(binding, index, route.proportionOfSectionTime, correctionValue)
@@ -109,11 +109,7 @@ class TimeLineContainer(
 
         binding.imageViewIcon.setImageDrawable(drawable)
 
-        when (route) {
-            is TransportRoute -> setIdentityColor(binding, route)
-            else -> setDefaultColor(binding)
-        }
-
+        setIdentityColor(binding, route)
         setConstraint(binding, index, route.proportionOfSectionTime, correctionValue)
     }
 
@@ -169,22 +165,17 @@ class TimeLineContainer(
         beforeViewId = binding.root.id
     }
 
-    private fun setIdentityColor(binding: ItemTimeLineBinding, route: TransportRoute) {
-        val identityColor = Color.parseColor("#${route.routeColor}")
+    private fun setIdentityColor(binding: ItemTimeLineBinding, route: RouteInfo) {
+        val color = if (route.mode == MoveType.WALK) {
+            walkColor
+        } else {
+            Color.WHITE
+        }
+        binding.textViewSectionTime.background.setTint(route.symbolColor)
+        binding.textViewSectionTime.setTextColor(color)
 
-        binding.textViewSectionTime.background.setTint(identityColor)
-        binding.textViewSectionTime.setTextColor(Color.WHITE)
-
-        binding.viewIcon.background.setTint(identityColor)
-        binding.imageViewIcon.imageTintList = ColorStateList.valueOf(Color.WHITE)
-    }
-
-    private fun setDefaultColor(binding: ItemTimeLineBinding) {
-        binding.textViewSectionTime.background.setTint(greyColor)
-        binding.textViewSectionTime.setTextColor(Color.WHITE)
-
-        binding.viewIcon.background.setTint(greyColor)
-        binding.imageViewIcon.imageTintList = ColorStateList.valueOf(Color.WHITE)
+        binding.viewIcon.background.setTint(route.symbolColor)
+        binding.imageViewIcon.imageTintList = ColorStateList.valueOf(color)
     }
 
     companion object {

--- a/presentation/src/main/java/com/stop/ui/route/TimeLineViewPool.kt
+++ b/presentation/src/main/java/com/stop/ui/route/TimeLineViewPool.kt
@@ -1,0 +1,15 @@
+package com.stop.ui.route
+
+import com.stop.databinding.ItemTimeLineBinding
+
+object TimeLineViewPool {
+    private val views = ArrayList<ItemTimeLineBinding>()
+
+    fun getRecycledView(): ItemTimeLineBinding? {
+        return views.removeLastOrNull()
+    }
+
+    fun putRecycledView(view: ItemTimeLineBinding) {
+        views.add(view)
+    }
+}

--- a/presentation/src/main/res/layout/item_route.xml
+++ b/presentation/src/main/res/layout/item_route.xml
@@ -73,6 +73,7 @@
     <com.google.android.material.divider.MaterialDivider
         android:layout_width="match_parent"
         android:layout_height="1dp"
+        android:layout_marginTop="10dp"
         app:dividerColor="@color/main_lighter_grey"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/station_container" />

--- a/presentation/src/main/res/layout/item_route_header.xml
+++ b/presentation/src/main/res/layout/item_route_header.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/tv_total_time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:textColor="@color/black"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="30" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/required_minute"
+        android:textColor="@color/black"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/tv_total_time"
+        app:layout_constraintStart_toEndOf="@id/tv_total_time" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/item_route_last.xml
+++ b/presentation/src/main/res/layout/item_route_last.xml
@@ -82,7 +82,7 @@
         app:layout_constraintTop_toTopOf="@id/image_view_current_line" />
 
     <View
-        android:id="@+id/view_line"
+        android:id="@+id/v_line"
         android:layout_width="0dp"
         android:layout_height="1dp"
         android:layout_marginStart="15dp"

--- a/presentation/src/main/res/layout/item_route_path.xml
+++ b/presentation/src/main/res/layout/item_route_path.xml
@@ -118,7 +118,7 @@
         tools:src="@drawable/ic_walk_white" />
 
     <View
-        android:id="@+id/view_line"
+        android:id="@+id/v_line"
         android:layout_width="0dp"
         android:layout_height="1dp"
         android:layout_marginStart="15dp"

--- a/presentation/src/main/res/layout/item_route_station.xml
+++ b/presentation/src/main/res/layout/item_route_station.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <View
+        android:id="@+id/v_top_vertical_line"
+        android:layout_width="2dp"
+        android:layout_height="12dp"
+        android:background="@color/station_line_color"
+        app:layout_constraintBottom_toTopOf="@id/iv_type_icon"
+        app:layout_constraintEnd_toEndOf="@id/iv_type_icon"
+        app:layout_constraintStart_toStartOf="@id/iv_type_icon"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/iv_type_icon"
+        android:layout_width="18dp"
+        android:layout_height="18dp"
+        android:layout_marginStart="12dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/v_top_vertical_line"
+        tools:src="@drawable/time_line_subway_16"
+        tools:tint="@color/blue" />
+
+    <View
+        android:id="@+id/v_Bottom_vertical_line"
+        android:layout_width="2dp"
+        android:layout_height="12dp"
+        android:background="@color/station_line_color"
+        app:layout_constraintEnd_toEndOf="@id/iv_type_icon"
+        app:layout_constraintStart_toStartOf="@id/iv_type_icon"
+        app:layout_constraintTop_toBottomOf="@id/iv_type_icon" />
+
+    <TextView
+        android:id="@+id/tv_type_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:minEms="4"
+        app:layout_constraintBottom_toBottomOf="@id/iv_type_icon"
+        app:layout_constraintStart_toEndOf="@id/iv_type_icon"
+        app:layout_constraintTop_toTopOf="@id/iv_type_icon"
+        tools:text="1호선"
+        tools:textColor="@color/blue" />
+
+    <TextView
+        android:id="@+id/tv_location"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:maxLines="1"
+        android:ellipsize="end"
+        android:gravity="start"
+        app:layout_constraintBottom_toBottomOf="@id/iv_type_icon"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/tv_type_name"
+        app:layout_constraintTop_toTopOf="@id/iv_type_icon"
+        tools:text="노량진역" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/item_station_container.xml
+++ b/presentation/src/main/res/layout/item_station_container.xml
@@ -29,7 +29,7 @@
         android:minEms="4"
         android:textColor="@color/main_light_grey"
         android:textSize="13sp"
-        app:layout_constraintBottom_toTopOf="@id/view_line"
+        app:layout_constraintBottom_toTopOf="@id/v_line"
         app:layout_constraintStart_toEndOf="@id/image_view_current_line"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="에버라인" />
@@ -45,7 +45,7 @@
         android:maxEms="12"
         android:textColor="@color/main_dark_grey"
         android:textSize="15sp"
-        app:layout_constraintBottom_toTopOf="@id/view_line"
+        app:layout_constraintBottom_toTopOf="@id/v_line"
         app:layout_constraintStart_toEndOf="@id/text_view_type_name"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="미금역.청솔마을.2001.아울렛123123" />
@@ -104,7 +104,7 @@
         tools:src="@drawable/ic_walk_white" />
 
     <View
-        android:id="@+id/view_line"
+        android:id="@+id/v_line"
         android:layout_width="0dp"
         android:layout_height="1dp"
         android:layout_marginStart="-15dp"

--- a/presentation/src/main/res/layout/item_time_line.xml
+++ b/presentation/src/main/res/layout/item_time_line.xml
@@ -12,6 +12,7 @@
         android:background="@drawable/time_stick_border"
         android:gravity="center"
         android:textSize="11sp"
+        android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@id/dummy_view"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@id/dummy_view"

--- a/presentation/src/main/res/values/colors.xml
+++ b/presentation/src/main/res/values/colors.xml
@@ -7,8 +7,10 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="grey_for_route_walk">#C0C5CA</color>
+    <color name="grey_for_route_walk">#6A6F7A</color>
 
+    <color name="station_line_color">#E5EAF1</color>
+    <color name="walk_color">#E2E7EE</color>
     <color name="light_grey">#D3CCCC</color>
     <color name="gray_d9">#D9D9D9</color>
     <color name="main_dark_grey">#404550</color>
@@ -19,7 +21,7 @@
     <color name="main_yellow">#FFC766</color>
     <color name="transparent">#00FFFFFF</color>
     <color name="hint_text_color">#808590</color>
-    <color name="blue">#2196F3</color>
+    <color name="blue">#0000FF</color>
     <color name="red">#F44336</color>
     <color name="light_yellow">#FDDCA4</color>
     <color name="mint">#5DC19B</color>


### PR DESCRIPTION
## 경로 검색 결화 화면 성능 개선

첫 번째로, onBind 시점에 하던 작업을 ViewModel에서 처리하도록 함으로써 연산 작업을 줄였습니다.

두 번째로, ViewHolder의 Custom View에서 inflate한 View들을 매번 새롭게 생성하지 않고, 이미 생성한 View들을 재활용하도록 로직을 수정했습니다.(View가 다시 사용될 수 있도록 parent와의 연결을 끊고, 별도의 Object Pool에 추가함)

아래 영상에서는 테스트를 위해 출발지, 도착지와 무관하게 동일한 경로 데이터를 반환하도록 설정했습니다.
경로 데이터가 많다보니, 비교적 Layout을 그리는 시간이 오래 걸리는데, 네이버 지도에서도 경로 데이터가 많으면 비슷한 시간이 소요됐습니다.

https://github.com/DoTheBestMayB/PlzStopRe/assets/48354989/ed49e370-6852-4731-a6d5-22d5a9c8f975

https://github.com/DoTheBestMayB/PlzStopRe/assets/48354989/8c6caf37-24a3-4987-b78f-00baf1f9f52a


View들이 재활용되는 시점은 ViewHolder가 화면에 보이지 않는 순간이 아닌, ViewHolder가 Recycled 되는 시점으로 설정했습니다.
ViewHolder가 화면에 보이지 않으면 즉시 Recycled Pool에 가지 않고 캐싱된 상태가 되며, 캐싱된지 오래될 경우 Recycled Pool로 이동합니다.

그래서 ViewHolder가 화면에 더 이상 보이지 않는 시점에 호출되는 onViewDetachedFromWindow 함수가 아닌, ViewHolder가 재활용되기 직전에 호출되는 onViewRecycled 함수에서 View의 재활용 로직을 실행했습니다.

만약, onViewDetachedFromWindow 함수에서 View를 재활용할 경우 재활용된 View가 보이지 않는 문제가 발생합니다. 캐시된 상태의 ViewHolder가 다시 보이게 될 때 onBind가 호출되지 않기 때문입니다.

아래 영상에서 시간만 보이는 부분이 캐싱된 상태에서 View가 재활용되었지만, onBind가 호출되지 않은 경우입니다.

https://github.com/DoTheBestMayB/PlzStopRe/assets/48354989/4b078db7-dfc8-4beb-b45c-67ce39d4900c
